### PR TITLE
awk can do regex, negates grep process call

### DIFF
--- a/polybar/polysubs
+++ b/polybar/polysubs
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-Main="$(curl -s https://www.youtube.com/channel/UCld68syR8Wi-GY_n4CaoJGA | grep -i "subscribers" | awk -F\> '{print $19}' | awk -F\< '{print $1}'
+Main="$(curl -s https://www.youtube.com/channel/UCld68syR8Wi-GY_n4CaoJGA | awk -F\> '/subscribers/ {print $19}' | awk -F\< '{print $1}'
 )"
 
-Podcast="$(curl -s https://www.youtube.com/channel/UCBq5p-xOla8xhnrbhu8AIAg | grep -i "subscribers" | awk -F\> '{print $19}' | awk -F\< '{print $1}'
+Podcast="$(curl -s https://www.youtube.com/channel/UCBq5p-xOla8xhnrbhu8AIAg | awk -F\> '/subscribers/ {print $19}' | awk -F\< '{print $1}'
 )"
 
 echo "🐧 $Main ☕ $Podcast"


### PR DESCRIPTION
no need to grep into awk, awk will perform the same behavior with its own regex search before grabbing the field/column value you list. saves a process call for each variable.