### PR TITLE
Exit out of search when no url has been selected

### DIFF
--- a/sch
+++ b/sch
@@ -3,6 +3,10 @@
 # To avoid issues with spaces and special characters html encoding is applied to the query
 
 url=$(sort ~/.config/search/search | sed 's/:.*//' | dmenu -i -p "Search Engine" | xargs -I % grep "%:" ~/.config/search/search | sed 's/.*://')
+
+# exit if no url was selected
+[ -z $url ] && exit 0
+
 search=$(sort ~/.config/search/search_history | dmenu -i -p "Search")
 
 # Echo to history file


### PR DESCRIPTION
When exiting the $url dmenu prompt with e.g. <ESC>, one would be prompted with 
the search dmenu anyways. This addition checks whether the second dmenu is even
necessary.